### PR TITLE
feat: update default font to inter

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>"RK Nuotykiai" - Kur prasideda nuotykiai!</title>
   </head>
-  <body class="font-poppins">
+  <body class="font-inter">
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -15,7 +15,7 @@ export const ThemeProvider = ({ children }) => {
   useEffect(() => {
     const body = document.body;
 
-    body.classList.add('min-h-screen', 'flex', 'flex-col', 'font-poppins', 'transition-colors', 'duration-300');
+    body.classList.add('min-h-screen', 'flex', 'flex-col', 'font-inter', 'transition-colors', 'duration-300');
 
     if (theme === 'light') {
       body.classList.add('bg-neutral-200', 'text-gray-800');

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
  
 @tailwind base;
 @tailwind components;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-              'poppins': ['"Poppins"', 'sans-serif'], // Added Poppins font
+              inter: ['"Inter"', 'sans-serif'], // Use Inter font
       },
       // Jei naudojate spalvas, kurios nėra default Tailwind paletėje,
       // turėsite jas apibrėžti čia.


### PR DESCRIPTION
## Summary
- switch global font to Inter
- configure Tailwind to use the new font

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b08ba7effc832ca09a5da221179dcf